### PR TITLE
Improve closer to the sun mobile layout

### DIFF
--- a/app/concepts/_shared/DitherFire.tsx
+++ b/app/concepts/_shared/DitherFire.tsx
@@ -78,7 +78,10 @@ void main() {
 
     vec2 cellIdx = floor(frag / uCell);
     vec2 center = (cellIdx + 0.5) * uCell;
-    vec2 p = center / uSize.y;
+    // Normalize by the short axis: on landscape screens this matches the
+    // app's height-normalized field exactly, and on portrait phones it keeps
+    // several noise features on screen instead of zooming into one blob.
+    vec2 p = center / min(uSize.x, uSize.y);
 
     float t = uTime;
     float energy = mix(0.55, 1.0, uProgress);

--- a/app/concepts/_shared/DitherLight.tsx
+++ b/app/concepts/_shared/DitherLight.tsx
@@ -65,7 +65,9 @@ void main() {
 
     vec2 cellIdx = floor(frag / uCell);
     vec2 center = (cellIdx + 0.5) * uCell;
-    vec2 p = center / uSize.y;
+    // Short-axis normalization keeps the rim flicker scale consistent
+    // between landscape and portrait (see DitherFire).
+    vec2 p = center / min(uSize.x, uSize.y);
 
     float t = uTime;
 

--- a/app/concepts/closer-to-the-sun/SunSection.tsx
+++ b/app/concepts/closer-to-the-sun/SunSection.tsx
@@ -78,10 +78,11 @@ export default function SunSection() {
     }, []);
     const markShown = markLanded || (reduceMotion === true && featherArmed);
 
-    // 0 when the section is still a viewport away, 0.75 when its heart is centered.
+    // 0 when the section is still a viewport away, 0.75 when the scroll
+    // bottoms out — the sun peaks exactly where the page ends.
     const { scrollYProgress } = useScroll({
         target: sectionRef,
-        offset: ["start 200%", "center center"],
+        offset: ["start 200%", "end end"],
     });
     useMotionValueEvent(scrollYProgress, "change", (v) => {
         setScrollHeat(Math.round(v * 75) / 100);
@@ -137,7 +138,7 @@ export default function SunSection() {
 
             {featherArmed && !reduceMotion && <DriftingFeather />}
 
-            <div className="relative z-10 mx-auto flex min-h-[135vh] max-w-3xl flex-col items-center justify-center px-6 py-32 text-center">
+            <div className="relative z-10 mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 py-32 text-center">
                 {/* The flight path ends here: wing meets sun. */}
                 <span data-flight-anchor aria-hidden className="mb-8 block h-2 w-2" />
 
@@ -199,7 +200,7 @@ export default function SunSection() {
 
                 {/* Quiet footer, inside the sun. */}
                 <div
-                    className="mt-24 flex items-center gap-7 text-[13px]"
+                    className="mt-24 flex flex-wrap items-center justify-center gap-x-7 gap-y-3 text-[13px]"
                     style={{ color: palette.muted }}
                 >
                     <a

--- a/app/concepts/closer-to-the-sun/TorchlitExtras.tsx
+++ b/app/concepts/closer-to-the-sun/TorchlitExtras.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
-import { useMotionValueEvent, useReducedMotion, useScroll } from "framer-motion";
+import { motion, useMotionValueEvent, useReducedMotion, useScroll } from "framer-motion";
 
 import DitherLight from "../_shared/DitherLight";
 import { palette } from "../_shared/tokens";
@@ -40,6 +40,21 @@ function outCubic(t: number) {
     return 1 - Math.pow(1 - t, 3);
 }
 
+function CardFace({ extra }: { extra: Extra }) {
+    const Icon = extra.icon;
+    return (
+        <>
+            <Icon size={16} color={palette.lavender} aria-hidden />
+            <p className="callsign mt-4" style={{ color: palette.fg }}>
+                {extra.tag}
+            </p>
+            <p className="mt-2 text-[13.5px] leading-[1.6]" style={{ color: palette.muted }}>
+                {extra.detail}
+            </p>
+        </>
+    );
+}
+
 function FeatureCard({
     extra,
     x,
@@ -55,7 +70,6 @@ function FeatureCard({
     rotate: number;
     lit: number;
 }) {
-    const Icon = extra.icon;
     return (
         <div
             className="absolute left-1/2 top-1/2 rounded-xl border p-6"
@@ -68,13 +82,7 @@ function FeatureCard({
                 transition: "border-color 200ms ease",
             }}
         >
-            <Icon size={16} color={palette.lavender} aria-hidden />
-            <p className="callsign mt-4" style={{ color: palette.fg }}>
-                {extra.tag}
-            </p>
-            <p className="mt-2 text-[13.5px] leading-[1.6]" style={{ color: palette.muted }}>
-                {extra.detail}
-            </p>
+            <CardFace extra={extra} />
         </div>
     );
 }
@@ -131,14 +139,50 @@ export default function TorchlitExtras() {
     const torch = p < 0.7 ? (p / 0.7) * 0.62 : Math.max(0.1, 0.62 - ((p - 0.7) / 0.3) * 0.52);
 
     return (
-        <section id="extras" ref={sectionRef} className="relative h-[240vh]">
+        <section id="extras" ref={sectionRef} className="relative md:h-[240vh]">
             {/* Flight anchors: the comet falls past the pinned screens. */}
             <span data-flight-anchor aria-hidden className="absolute right-[18%] top-[6%] h-2 w-2" />
             <span data-flight-anchor aria-hidden className="absolute left-[16%] top-[92%] h-2 w-2" />
 
             <ExtrasInventory />
 
-            <div className="sticky top-0 h-screen overflow-hidden">
+            {/* Mobile: the constellation doesn't fit, so the torch lights a
+                plain stack instead — nothing lost. */}
+            <div className="px-6 py-24 md:hidden" aria-hidden>
+                <div className="flex flex-col items-center">
+                    <Image src="/assets/torch.png" alt="" width={48} height={48} />
+                    <p className="callsign mt-6" style={{ color: palette.muted }}>
+                        and the rest
+                    </p>
+                    <div className="mt-10">
+                        <IcarusMark
+                            size={96}
+                            style={{ display: "block", filter: "drop-shadow(0 0 18px rgba(196,181,253,0.28))" }}
+                        />
+                    </div>
+                </div>
+                <div className="mx-auto mt-12 flex max-w-[420px] flex-col gap-4">
+                    {EXTRAS.map((extra, i) => (
+                        <motion.div
+                            key={extra.tag}
+                            className="rounded-xl border p-6"
+                            style={{
+                                background: palette.card,
+                                borderColor: palette.border,
+                                rotate: TILT[i % TILT.length] * 0.4,
+                            }}
+                            initial={{ opacity: 0, y: 24 }}
+                            whileInView={{ opacity: 1, y: 0 }}
+                            viewport={{ once: true, margin: "-40px" }}
+                            transition={{ duration: 0.5, ease: "easeOut" }}
+                        >
+                            <CardFace extra={extra} />
+                        </motion.div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="sticky top-0 hidden h-screen overflow-hidden md:block">
                 <div className="absolute inset-0">
                     <DitherLight progress={torch} light={{ x: 0.5, y: 0.52 }} cell={9} />
                 </div>


### PR DESCRIPTION
## Summary

- improve portrait shader scaling by normalizing against the short viewport axis
- add a dedicated stacked mobile layout for the extras section
- align the sun reveal with the page end and make footer links wrap cleanly

## Why

The closer-to-the-sun concept needed a more usable mobile presentation. The desktop constellation layout does not fit narrow screens, and height-only shader normalization zoomed too far into the effect in portrait orientation.

## Impact

Mobile visitors now see every extras card in a readable animated stack, with more consistent dither effects and a sun sequence that completes at the end of the page. Desktop behavior remains on the existing pinned constellation layout.

## Validation

- ESLint passed for all four changed source files
- `git diff --cached --check` passed before commit
- Full-project lint is currently blocked by lint errors in untracked `.assets-gen` helper scripts, which are not part of this PR
